### PR TITLE
Add new kernel patches for new hw-management V.7.0020.4001

### DIFF
--- a/patch/0174-core-Add-support-for-OSFP-transceiver-modules.patch
+++ b/patch/0174-core-Add-support-for-OSFP-transceiver-modules.patch
@@ -1,0 +1,59 @@
+From 2d0cae902b722594b17335e7aceb6500d9bb4525 Mon Sep 17 00:00:00 2001
+From: Danielle Ratson <danieller@nvidia.com>
+Date: Tue, 22 Feb 2022 19:17:03 +0200
+Subject: [PATCH platform backport v5.10 1/1] mlxsw: core: Add support for OSFP
+ transceiver modules
+
+The driver can already dump the EEPROM contents of QSFP-DD transceiver
+modules via its ethtool_ops::get_module_info() and
+ethtool_ops::get_module_eeprom() callbacks.
+
+Add support for OSFP transceiver modules by adding their SFF-8024
+Identifier Value (0x19).
+
+This is required for future NVIDIA Spectrum-4 based systems that will be
+equipped with OSFP transceivers.
+
+Signed-off-by: Danielle Ratson <danieller@nvidia.com>
+Signed-off-by: Ido Schimmel <idosch@nvidia.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_env.c | 2 ++
+ drivers/net/ethernet/mellanox/mlxsw/reg.h      | 1 +
+ 2 files changed, 3 insertions(+)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_env.c b/drivers/net/ethernet/mellanox/mlxsw/core_env.c
+index 98f7cf672d9e..f9c770eec8f8 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_env.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_env.c
+@@ -61,6 +61,7 @@ mlxsw_env_validate_cable_ident(struct mlxsw_core *core, u8 slot_index, int id,
+ 		*qsfp = true;
+ 		break;
+ 	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_DD:
++	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_OSFP:
+ 		*qsfp = true;
+ 		*cmis = true;
+ 		break;
+@@ -275,6 +276,7 @@ int mlxsw_env_get_module_info(struct mlxsw_core *mlxsw_core, u8 slot_index,
+ 			modinfo->eeprom_len = ETH_MODULE_SFF_8472_LEN / 2;
+ 		break;
+ 	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_DD:
++	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_OSFP:
+ 		/* Use SFF_8636 as base type. ethtool should recognize specific
+ 		 * type through the identifier value.
+ 		 */
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/reg.h b/drivers/net/ethernet/mellanox/mlxsw/reg.h
+index ce3842ed8460..bec9d94b718a 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/reg.h
++++ b/drivers/net/ethernet/mellanox/mlxsw/reg.h
+@@ -8950,6 +8950,7 @@ enum mlxsw_reg_mcia_eeprom_module_info_id {
+ 	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_PLUS	= 0x0D,
+ 	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP28	= 0x11,
+ 	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_DD	= 0x18,
++	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_OSFP	= 0x19,
+ };
+ 
+ enum mlxsw_reg_mcia_eeprom_module_info {
+-- 
+2.20.1
+

--- a/patch/0175-hwmon-pmbus-Add-support-for-Infineon-Digital-Multi-p.patch
+++ b/patch/0175-hwmon-pmbus-Add-support-for-Infineon-Digital-Multi-p.patch
@@ -1,0 +1,271 @@
+From 0daa4a8f50be59f0549bbda2d06ad5b74d5134bd Mon Sep 17 00:00:00 2001
+From: "Greg.Schwendimann@infineon.com" <Greg.Schwendimann@infineon.com>
+Date: Wed, 27 Apr 2022 18:40:12 +0000
+Subject: [PATCH hwmon backport v5.10 1/1] hwmon: (pmbus) Add support for
+ Infineon Digital Multi-phase xdp152 family controllers
+
+Add support for devices XDPE152C4, XDPE12584.
+
+Signed-off-by: Greg Schwendimann <Greg.Schwendimann@infineon.com>
+Link: https://lore.kernel.org/r/5e6d50e9b28140158f339b0de343eea4@infineon.com
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+---
+ Documentation/hwmon/index.rst     |   1 +
+ Documentation/hwmon/xdpe152c4.rst | 118 ++++++++++++++++++++++++++++++
+ drivers/hwmon/pmbus/Kconfig       |   9 +++
+ drivers/hwmon/pmbus/Makefile      |   1 +
+ drivers/hwmon/pmbus/xdpe152c4.c   |  75 +++++++++++++++++++
+ 5 files changed, 204 insertions(+)
+ create mode 100644 Documentation/hwmon/xdpe152c4.rst
+ create mode 100644 drivers/hwmon/pmbus/xdpe152c4.c
+
+diff --git a/Documentation/hwmon/index.rst b/Documentation/hwmon/index.rst
+index b797db738225..cd280009709c 100644
+--- a/Documentation/hwmon/index.rst
++++ b/Documentation/hwmon/index.rst
+@@ -194,6 +194,7 @@ Hardware Monitoring Kernel Drivers
+    wm8350
+    xgene-hwmon
+    xdpe12284
++   xdpe152c4
+    zl6100
+ 
+ .. only::  subproject and html
+diff --git a/Documentation/hwmon/xdpe152c4.rst b/Documentation/hwmon/xdpe152c4.rst
+new file mode 100644
+index 000000000000..ab92c32d4d69
+--- /dev/null
++++ b/Documentation/hwmon/xdpe152c4.rst
+@@ -0,0 +1,118 @@
++.. SPDX-License-Identifier: GPL-2.0
++
++Kernel driver xdpe152
++=====================
++
++Supported chips:
++
++  * Infineon XDPE152C4
++
++    Prefix: 'xdpe152c4'
++
++  * Infineon XDPE15284
++
++    Prefix: 'xdpe15284'
++
++Authors:
++
++    Greg Schwendimann <greg.schwendimann@infineon.com>
++
++Description
++-----------
++
++This driver implements support for Infineon Digital Multi-phase Controller
++XDPE152C4 and XDPE15284 dual loop voltage regulators.
++The devices are compliant with:
++
++- Intel VR13, VR13HC and VR14 rev 1.86
++  converter specification.
++- Intel SVID rev 1.93. protocol.
++- PMBus rev 1.3.1 interface.
++
++Devices support linear format for reading input and output voltage, input
++and output current, input and output power and temperature.
++
++Devices support two pages for telemetry.
++
++The driver provides for current: input, maximum and critical thresholds
++and maximum and critical alarms. Low Critical thresholds and Low critical alarm are
++supported only for current output.
++The driver exports the following attributes for via the sysfs files, where
++indexes 1, 2 are for "iin" and 3, 4 for "iout":
++
++**curr[1-4]_crit**
++
++**curr[1-4]_crit_alarm**
++
++**curr[1-4]_input**
++
++**curr[1-4]_label**
++
++**curr[1-4]_max**
++
++**curr[1-4]_max_alarm**
++
++**curr[3-4]_lcrit**
++
++**curr[3-4]_lcrit_alarm**
++
++**curr[3-4]_rated_max**
++
++The driver provides for voltage: input, critical and low critical thresholds
++and critical and low critical alarms.
++The driver exports the following attributes for via the sysfs files, where
++indexes 1, 2 are for "vin" and 3, 4 for "vout":
++
++**in[1-4]_min**
++
++**in[1-4]_crit**
++
++**in[1-4_crit_alarm**
++
++**in[1-4]_input**
++
++**in[1-4]_label**
++
++**in[1-4]_max**
++
++**in[1-4]_max_alarm**
++
++**in[1-4]_min**
++
++**in[1-4]_min_alarm**
++
++**in[3-4]_lcrit**
++
++**in[3-4]_lcrit_alarm**
++
++**in[3-4]_rated_max**
++
++**in[3-4]_rated_min**
++
++The driver provides for power: input and alarms.
++The driver exports the following attributes for via the sysfs files, where
++indexes 1, 2 are for "pin" and 3, 4 for "pout":
++
++**power[1-2]_alarm**
++
++**power[1-4]_input**
++
++**power[1-4]_label**
++
++**power[1-4]_max**
++
++**power[1-4]_rated_max**
++
++The driver provides for temperature: input, maximum and critical thresholds
++and maximum and critical alarms.
++The driver exports the following attributes for via the sysfs files:
++
++**temp[1-2]_crit**
++
++**temp[1-2]_crit_alarm**
++
++**temp[1-2]_input**
++
++**temp[1-2]_max**
++
++**temp[1-2]_max_alarm**
+diff --git a/drivers/hwmon/pmbus/Kconfig b/drivers/hwmon/pmbus/Kconfig
+index 41ff2bb28f0b..ee94fcfde685 100644
+--- a/drivers/hwmon/pmbus/Kconfig
++++ b/drivers/hwmon/pmbus/Kconfig
+@@ -276,6 +276,15 @@ config SENSORS_UCD9200
+ 	  This driver can also be built as a module. If so, the module will
+ 	  be called ucd9200.
+ 
++config SENSORS_XDPE152
++	tristate "Infineon XDPE152 family"
++	help
++	  If you say yes here you get hardware monitoring support for Infineon
++	  XDPE15284, XDPE152C4, device.
++
++	  This driver can also be built as a module. If so, the module will
++	  be called xdpe152c4.
++
+ config SENSORS_XDPE122
+ 	tristate "Infineon XDPE122 family"
+ 	help
+diff --git a/drivers/hwmon/pmbus/Makefile b/drivers/hwmon/pmbus/Makefile
+index 8861a1b71acb..b1b9a3c8b616 100644
+--- a/drivers/hwmon/pmbus/Makefile
++++ b/drivers/hwmon/pmbus/Makefile
+@@ -32,4 +32,5 @@ obj-$(CONFIG_SENSORS_TPS53679)	+= tps53679.o
+ obj-$(CONFIG_SENSORS_UCD9000)	+= ucd9000.o
+ obj-$(CONFIG_SENSORS_UCD9200)	+= ucd9200.o
+ obj-$(CONFIG_SENSORS_XDPE122)	+= xdpe12284.o
++obj-$(CONFIG_SENSORS_XDPE152)	+= xdpe152c4.o
+ obj-$(CONFIG_SENSORS_ZL6100)	+= zl6100.o
+diff --git a/drivers/hwmon/pmbus/xdpe152c4.c b/drivers/hwmon/pmbus/xdpe152c4.c
+new file mode 100644
+index 000000000000..b8a36ef73e45
+--- /dev/null
++++ b/drivers/hwmon/pmbus/xdpe152c4.c
+@@ -0,0 +1,75 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Hardware monitoring driver for Infineon Multi-phase Digital VR Controllers
++ *
++ * Copyright (c) 2022 Infineon Technologies. All rights reserved.
++ */
++
++#include <linux/err.h>
++#include <linux/i2c.h>
++#include <linux/init.h>
++#include <linux/kernel.h>
++#include <linux/module.h>
++#include "pmbus.h"
++
++#define XDPE152_PAGE_NUM 2
++
++static struct pmbus_driver_info xdpe152_info = {
++	.pages = XDPE152_PAGE_NUM,
++	.format[PSC_VOLTAGE_IN] = linear,
++	.format[PSC_VOLTAGE_OUT] = linear,
++	.format[PSC_TEMPERATURE] = linear,
++	.format[PSC_CURRENT_IN] = linear,
++	.format[PSC_CURRENT_OUT] = linear,
++	.format[PSC_POWER] = linear,
++	.func[0] = PMBUS_HAVE_VIN | PMBUS_HAVE_VOUT | PMBUS_HAVE_STATUS_VOUT |
++		PMBUS_HAVE_IIN | PMBUS_HAVE_IOUT | PMBUS_HAVE_STATUS_IOUT |
++		PMBUS_HAVE_TEMP | PMBUS_HAVE_TEMP2 | PMBUS_HAVE_STATUS_TEMP |
++		PMBUS_HAVE_POUT | PMBUS_HAVE_PIN | PMBUS_HAVE_STATUS_INPUT,
++	.func[1] = PMBUS_HAVE_VIN | PMBUS_HAVE_VOUT | PMBUS_HAVE_STATUS_VOUT |
++		PMBUS_HAVE_IIN | PMBUS_HAVE_IOUT | PMBUS_HAVE_STATUS_IOUT |
++		PMBUS_HAVE_POUT | PMBUS_HAVE_PIN | PMBUS_HAVE_STATUS_INPUT,
++};
++
++static int xdpe152_probe(struct i2c_client *client)
++{
++	struct pmbus_driver_info *info;
++
++	info = devm_kmemdup(&client->dev, &xdpe152_info, sizeof(*info),
++			    GFP_KERNEL);
++	if (!info)
++		return -ENOMEM;
++
++	return pmbus_do_probe(client, info);
++}
++
++static const struct i2c_device_id xdpe152_id[] = {
++	{"xdpe152c4", 0},
++	{"xdpe15284", 0},
++	{}
++};
++
++MODULE_DEVICE_TABLE(i2c, xdpe152_id);
++
++static const struct of_device_id __maybe_unused xdpe152_of_match[] = {
++	{.compatible = "infineon,xdpe152c4"},
++	{.compatible = "infineon,xdpe15284"},
++	{}
++};
++MODULE_DEVICE_TABLE(of, xdpe152_of_match);
++
++static struct i2c_driver xdpe152_driver = {
++	.driver = {
++		.name = "xdpe152c4",
++		.of_match_table = of_match_ptr(xdpe152_of_match),
++	},
++	.probe_new = xdpe152_probe,
++	.id_table = xdpe152_id,
++};
++
++module_i2c_driver(xdpe152_driver);
++
++MODULE_AUTHOR("Greg Schwendimann <greg.schwendimann@infineon.com>");
++MODULE_DESCRIPTION("PMBus driver for Infineon XDPE152 family");
++MODULE_LICENSE("GPL");
++MODULE_IMPORT_NS(PMBUS);
+-- 
+2.20.1
+

--- a/patch/series
+++ b/patch/series
@@ -144,6 +144,8 @@ kernel-compat-always-include-linux-compat.h-from-net-compat.patch
 0098-mlxsw-i2c-Prevent-transaction-execution-for.patch
 0163-platform-mellanox-Add-COME-board-revision-register.patch
 0167-leds-mlxreg-Send-udev-change-event.patch
+0174-core-Add-support-for-OSFP-transceiver-modules.patch
+0175-hwmon-pmbus-Add-support-for-Infineon-Digital-Multi-p.patch
 
 # Cisco patches for 5.10 kernel
 cisco-mtd-part.patch


### PR DESCRIPTION
Patch list:

- 0174-core-Add-support-for-OSFP-transceiver-modules.patch torvalds/linux@f881c4ab37db1e0ef35b2aef96bb139a95f2c545
- 0175-hwmon-pmbus-Add-support-for-Infineon-Digital-Multi-p.patch torvalds/linux@9054416afcb443933c16f9e8c4531086e62eb689

Signed-off-by: Stephen Sun <stephens@nvidia.com>